### PR TITLE
Export functions and add isByteSequence utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.4.1",
       "license": "MIT",
       "devDependencies": {
+        "@types/chai": "^4.3.3",
+        "@types/mocha": "^9.1.1",
         "@types/node": "^12.20.13",
         "@typescript-eslint/eslint-plugin": "^4.23.0",
         "@typescript-eslint/parser": "^4.23.0",
@@ -570,6 +572,12 @@
       "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
       "dev": true
     },
+    "node_modules/@types/chai": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
+      "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
+      "dev": true
+    },
     "node_modules/@types/eslint": {
       "version": "7.2.13",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.13.tgz",
@@ -600,6 +608,12 @@
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+      "dev": true
+    },
+    "node_modules/@types/mocha": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -5124,6 +5138,12 @@
       "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
       "dev": true
     },
+    "@types/chai": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
+      "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
+      "dev": true
+    },
     "@types/eslint": {
       "version": "7.2.13",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.13.tgz",
@@ -5154,6 +5174,12 @@
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
+      "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   ],
   "homepage": "https://github.com/evert/structured-header#readme",
   "devDependencies": {
+    "@types/chai": "^4.3.3",
+    "@types/mocha": "^9.1.1",
     "@types/node": "^12.20.13",
     "@typescript-eslint/eslint-plugin": "^4.23.0",
     "@typescript-eslint/parser": "^4.23.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './serializer';
 export * from './parser';
 export * from './types';
+export * from './util';
 export { Token } from './token';

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -57,14 +57,14 @@ export function serializeItem(input: Item): string {
 
 }
 
-function serializeInnerList(input: InnerList): string {
+export function serializeInnerList(input: InnerList): string {
 
   return `(${input[0].map(value => serializeItem(value)).join(' ')})${serializeParameters(input[1])}`;
 
 }
 
 
-function serializeBareItem(input: BareItem): string {
+export function serializeBareItem(input: BareItem): string {
   if (typeof input === 'number') {
     if (Number.isInteger(input)) {
       return serializeInteger(input);
@@ -86,7 +86,7 @@ function serializeBareItem(input: BareItem): string {
   throw new SerializeError(`Cannot serialize values of type ${typeof input}`);
 }
 
-function serializeInteger(input: number): string {
+export function serializeInteger(input: number): string {
 
   if (input < -999_999_999_999_999 || input > 999_999_999_999_999) {
     throw new SerializeError('Structured headers can only encode integers in the range range of -999,999,999,999,999 to 999,999,999,999,999 inclusive');
@@ -94,7 +94,7 @@ function serializeInteger(input: number): string {
   return input.toString();
 }
 
-function serializeDecimal(input: number): string {
+export function serializeDecimal(input: number): string {
   const out = input.toFixed(3).replace(/0+$/,'');
   const signifantDigits = out.split('.')[0].replace('-','').length;
 
@@ -104,26 +104,26 @@ function serializeDecimal(input: number): string {
   return out;
 }
 
-function serializeString(input: string): string {
+export function serializeString(input: string): string {
   if (!isAscii(input)) {
     throw new SerializeError('Only ASCII strings may be serialized');
   }
   return `"${input.replace(/("|\\)/g, (v) => '\\' + v)}"`;
 }
 
-function serializeBoolean(input: boolean): string {
+export function serializeBoolean(input: boolean): string {
   return input ? '?1' : '?0';
 }
 
-function serializeByteSequence(input: ByteSequence): string {
+export function serializeByteSequence(input: ByteSequence): string {
   return `:${input.toBase64()}:`;
 }
 
-function serializeToken(input: Token): string {
+export function serializeToken(input: Token): string {
   return input.toString();
 }
 
-function serializeParameters(input: Parameters): string {
+export function serializeParameters(input: Parameters): string {
 
   return Array.from(input).map(([key, value]) => {
 
@@ -137,7 +137,7 @@ function serializeParameters(input: Parameters): string {
 
 }
 
-function serializeKey(input: string): string {
+export function serializeKey(input: string): string {
 
   if (!isValidKeyStr(input)) {
     throw new SerializeError('Keys in dictionaries must only contain lowercase letter, numbers, _-*. and must start with a letter or *');

--- a/src/util.ts
+++ b/src/util.ts
@@ -31,5 +31,5 @@ export function isInnerList(input: Item | InnerList): input is InnerList {
 
 
 export function isByteSequence(input: BareItem): input is ByteSequence {
-    return typeof input === 'object' && 'base64Value' in input
+  return typeof input === 'object' && 'base64Value' in input;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import { Item, InnerList } from './types';
+import { Item, InnerList, BareItem, ByteSequence } from './types';
 
 const asciiRe = /^[\x20-\x7E]*$/;
 const tokenRe = /^[a-zA-Z*][:/!#$%&'*+\-.^_`|~A-Za-z0-9]*$/;
@@ -27,4 +27,9 @@ export function isInnerList(input: Item | InnerList): input is InnerList {
 
   return Array.isArray(input[0]);
 
+}
+
+
+export function isByteSequence(input: BareItem): input is ByteSequence {
+    return typeof input === 'object' && 'base64Value' in input
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -31,5 +31,7 @@ export function isInnerList(input: Item | InnerList): input is InnerList {
 
 
 export function isByteSequence(input: BareItem): input is ByteSequence {
+
   return typeof input === 'object' && 'base64Value' in input;
+
 }

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,0 +1,28 @@
+import { parseItem } from "../dist";
+
+const expect = require('chai').expect;
+const { isByteSequence } = require('../dist');
+
+describe('.isByteSequence', () => {
+
+    it('returns true for a valid Byte Sequence', () => {
+        const base64Value = `:${Buffer.from('TEST VALUE').toString('base64')}:`
+        const [item] = parseItem(base64Value)
+        expect(isByteSequence(item)).to.be.true
+    })
+
+    it('returns false for a number', () => {
+        const [item] = parseItem("98736459873465")
+        expect(isByteSequence(item)).to.be.false
+    })
+
+    it('returns false for a string', () => {
+        const [item] = parseItem('"TEST VALUE"')
+        expect(isByteSequence(item)).to.be.false
+    })
+
+    it('returns false for a JS object', () => {
+        expect(isByteSequence({})).to.be.false
+    })
+
+});


### PR DESCRIPTION
@evert @mihok @mhum @BeckyPollard we'd like to use this library as a dependancy in our project but we need these minor changes please.

It's useful to be able to, for example, directly serialize an Inner List for the sake of calculating the signature inputs for https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures-11

We'd like to avoid needing to publish our fork if we can, any chance you can publish this soon?