### PR TITLE
Implement the 'date' type

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "env": {
       "browser": true,
       "node": true,
-      "es6": true
+      "es6": true,
+      "mocha": true
   },
   "extends": [
       "eslint:recommended",

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,12 @@
 ChangeLog
 =========
 
+2.0.0 (????-??-??)
+------------------
+
+* Support for a new 'Date' type, from draft [draft-ietf-httpbis-sfbis-02][7].
+
+
 1.0.0 (2023-06-13)
 ------------------
 
@@ -84,9 +90,10 @@ ChangeLog
 * First version!
 * Parses all of the [04 draft of the specification][1].
 
-[1]: https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-04 [2]:
-https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-09 [3]:
-https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-10 [4]:
-https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-13 [5]:
-https://datatracker.ietf.org/doc/html/rfc8941 [6]:
-https://github.com/httpwg/structured-field-tests
+[1]: https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-04
+[2]: https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-09
+[3]: https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-10
+[4]: https://tools.ietf.org/html/draft-ietf-httpbis-header-structure-13
+[5]: https://datatracker.ietf.org/doc/html/rfc8941
+[6]: https://github.com/httpwg/structured-field-tests
+[7]: https://www.ietf.org/archive/id/draft-ietf-httpbis-sfbis-02.html

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ too, but plain Javascript is also fully supported.
 Compatibility
 -------------
 
-This package has 2725 unittests, the vast majority are supplied from the
+This package has 2740 unittests, the vast majority are supplied from the
 official [HTTP WG test suite][2].
 
 However, there are 2 differences in the serializer:

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -179,7 +179,9 @@ export default class Parser {
     if (char === '?') {
       return this.parseBoolean();
     }
-
+    if (char === '@') {
+      return this.parseDate();
+    }
     throw new ParseError(this.pos, 'Unexpected input');
 
   }
@@ -347,6 +349,34 @@ export default class Parser {
       return false;
     }
     throw new ParseError(this.pos, 'Unexpected character. Expected a "1" or a "0"');
+
+  }
+
+  private parseDate(): Date {
+
+    this.expectChar('@');
+    this.pos++;
+    let sign = 1;
+    let inputNumber = '';
+    if (this.lookChar()==='-') {
+      sign = -1;
+      this.pos++;
+    }
+
+    if (!isDigit(this.lookChar())) {
+      throw new ParseError(this.pos, 'Expected a digit (0-9)');
+    }
+
+    while(!this.eof()) {
+      const char = this.getChar();
+      if (isDigit(char)) {
+        inputNumber+=char;
+      } else {
+        throw new ParseError(this.pos, 'Expected a digit (0-9), whitespace or EOL');
+      }
+    }
+
+    return new Date(parseInt(inputNumber,10)*sign*1000);
 
   }
 

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -80,6 +80,9 @@ export function serializeBareItem(input: BareItem): string {
   if (input instanceof ByteSequence) {
     return serializeByteSequence(input);
   }
+  if (input instanceof Date) {
+    return serializeDate(input);
+  }
   if (typeof input === 'boolean') {
     return serializeBoolean(input);
   }
@@ -121,6 +124,10 @@ export function serializeByteSequence(input: ByteSequence): string {
 
 export function serializeToken(input: Token): string {
   return input.toString();
+}
+
+export function serializeDate(input: Date): string {
+  return '@' + Math.floor(input.getTime()/1000);
 }
 
 export function serializeParameters(input: Parameters): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,6 @@ export class ByteSequence {
 
 }
 
-export type BareItem = number | string | Token | ByteSequence | boolean;
+export type BareItem = number | string | Token | ByteSequence | Date | boolean;
 
 export type Item = [BareItem, Parameters];


### PR DESCRIPTION
There's a new version of the structured header fields being drafted, and one if its additions is a 'Date' type.

This PR implements this. This will not be released as stable until the RFC is stable, but if anyone reads this and wants an 'alpha', happy to oblige.